### PR TITLE
fix(audio): [RDK-1046] Fix hiwonder audio HAT no sound problem.

### DIFF
--- a/debian/boot/overlays/audio_hiwonder_rasadapter5b_x5_rdk.dts
+++ b/debian/boot/overlays/audio_hiwonder_rasadapter5b_x5_rdk.dts
@@ -37,7 +37,7 @@
         simple-audio-card,dai-link@0 {
             link-name = "dai-link0";
             reg = <0>;
-            format = "dsp_a";
+            format = "i2s";
             bitclock-master = <&snd1_mm>;
             frame-master = <&snd1_mm>;
             snd1_mm: cpu {


### PR DESCRIPTION
Summary:
- This audio daughterboard does not support the TDM protocol in FSYNC mode.